### PR TITLE
style: remove unused variables

### DIFF
--- a/baths.f90
+++ b/baths.f90
@@ -5,7 +5,6 @@ INTEGER, INTENT(INOUT) :: Backpack(200)
 CHARACTER :: Choice
 CHARACTER(20), INTENT(INOUT) :: HeroName
 CHARACTER(30), INTENT(INOUT) :: TownName
-CHARACTER :: Choice2
 
 DO
 WRITE (*,*) "--------------------------------------------------"

--- a/battle.f90
+++ b/battle.f90
@@ -1,7 +1,7 @@
 subroutine battle(heroabil,herohp, herohptot)
 implicit none
 integer, intent(inout) :: heroabil(3), herohp, herohptot
-integer :: i, enemabil(3), herooccupa(3)
+integer :: enemabil(3)
 integer :: heroroll, enemroll, decision, roll
 integer :: enemdamage, herodamage
 integer :: enemhp, enemhptot

--- a/generatehero.f90
+++ b/generatehero.f90
@@ -1,5 +1,5 @@
 subroutine generatehero(heroabil, herohp, herohptot,townname,backpack, heroname)
-integer :: herooccupa(3), roll
+integer :: roll
 integer, intent(inout) :: heroabil(3), herohp, herohptot
 INTEGER, INTENT(INOUT) :: Backpack(200)
 CHARACTER(20), INTENT(INOUT) :: HeroName

--- a/monastery.f90
+++ b/monastery.f90
@@ -6,7 +6,6 @@ CHARACTER :: Choice
 CHARACTER(20), INTENT(INOUT) :: HeroName
 CHARACTER(30), INTENT(INOUT) :: TownName
 
-CHARACTER :: Choice2
 DO
 WRITE (*,*) "--------------------------------------------------"
 WRITE (*,'(1X,A,A)') "The Monastery at ", TRIM(TownName)

--- a/rpg.f90
+++ b/rpg.f90
@@ -24,14 +24,11 @@
 PROGRAM Rpg
 
 IMPLICIT NONE
-INTEGER :: Roll
 CHARACTER :: Choice
 CHARACTER(20) :: HeroName
-INTEGER :: Seed_Size, TimeSave
+INTEGER :: Seed_Size
 INTEGER,ALLOCATABLE :: Seed(:)
 INTEGER :: Backpack(200)
-INTEGER :: HeroSpells(50)
-INTEGER :: HeroLevel
 CHARACTER(30) :: TownName
 integer :: heroabil(3), herohp, herohptot
 


### PR DESCRIPTION
This PR removes some unused variables (`-Wunused-variable` found them).

## Testing done:
After each commit I run `make clean && make`. At the end, I played a bit the game (visiting all of the _changed_ locations etc).

Now the code builds without warnings with the `-Wunused-variable`. Should it be added to the `Makefile`?